### PR TITLE
Perform relabel (restorecon) using find to support regexes

### DIFF
--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -38,8 +38,10 @@ use_inline_resources
 
 # Run restorecon to fix label
 action :relabel do
-  res = shell_out!("find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -type d -print0  2>/dev/null | xargs -0 restorecon -iR")
-  new_resource.updated_by_last_action(true) unless res.stdout.empty?
+  execute "selinux-fcontext-#{new_resource.secontext}-relabel" do
+    command "find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -type d -print0  2>/dev/null | xargs -0 restorecon -iRv"
+    only_if { use_selinux }
+  end
 end
 
 # Create if doesn't exist, do not touch if fcontext is already registered

--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -38,7 +38,7 @@ use_inline_resources
 
 # Run restorecon to fix label
 action :relabel do
-  res = shell_out!("find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -execdir restorecon -iRv {} \\;")
+  res = shell_out!('find','/','-regextype','posix-egrep','-regex',new_resource.file_spec,'-execdir','restorecon','-iRv', '{}', ';')
   new_resource.updated_by_last_action(true) unless res.stdout.empty?
 end
 

--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -38,7 +38,7 @@ use_inline_resources
 
 # Run restorecon to fix label
 action :relabel do
-  res = shell_out!('restorecon', '-irv', new_resource.file_spec)
+  res = shell_out!("find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -type d -print0  2>/dev/null | xargs -0 restorecon -iR")
   new_resource.updated_by_last_action(true) unless res.stdout.empty?
 end
 

--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -38,10 +38,8 @@ use_inline_resources
 
 # Run restorecon to fix label
 action :relabel do
-  execute "selinux-fcontext-#{new_resource.secontext}-relabel" do
-    command "find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -type d -print0  2>/dev/null | xargs -0 restorecon -iRv"
-    only_if { use_selinux }
-  end
+  res = shell_out!("find / -regextype posix-egrep -regex '#{new_resource.file_spec}' -execdir restorecon -iRv {} \\;")
+  new_resource.updated_by_last_action(true) unless res.stdout.empty?
 end
 
 # Create if doesn't exist, do not touch if fcontext is already registered

--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -38,7 +38,7 @@ use_inline_resources
 
 # Run restorecon to fix label
 action :relabel do
-  res = shell_out!('find','/','-regextype','posix-egrep','-regex',new_resource.file_spec,'-execdir','restorecon','-iRv', '{}', ';')
+  res = shell_out!('find', '/', '-regextype', 'posix-egrep', '-regex', new_resource.file_spec, '-execdir', 'restorecon', '-iRv', '{}', ';')
   new_resource.updated_by_last_action(true) unless res.stdout.empty?
 end
 


### PR DESCRIPTION
This replaces the shell_out with a find based command. It was still very fast for my use cases and works for regexes as well.
Fixes #56 