### PR TITLE
Add note to readme to not support Chef 12.16.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Needs an SELinux policy active (so its values can be managed). Can work with a d
 ### Chef
 
 - Chef 12.1+
+- Chef 12.16.42 is NOT supported (see [#55](https://github.com/sous-chefs/selinux_policy/issues/55))
 
 ### Platforms
 


### PR DESCRIPTION
There is a bug in Chef core that causes problemw with the custom resources in the cookbook
For more context see https://github.com/sous-chefs/selinux_policy/issues/55