### PR TITLE
Fix errant if statement in libraries/helpers.rb

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -14,7 +14,6 @@ class Chef
           selinux_disabled = getenforce.stdout =~ /disabled/i
         end
 
-        if getenforce.stdout =~ /Disabled|/i
         # return false only when SELinux is disabled and it's allowed
         return_val = !(selinux_disabled && new_resource.allowed_disabled)
         Chef::Log.warn('SELinux is disabled / unreachable, skipping') unless return_val


### PR DESCRIPTION
    $ ruby -c libraries/helpers.rb
    libraries/helpers.rb:87: syntax error, unexpected end-of-input, expecting keyword_end
    $ vi libraries/helpers.rb
    $ git diff libraries/helpers.rb
    diff --git a/libraries/helpers.rb b/libraries/helpers.rb
    index a354346..2fd0e8e 100644
    --- a/libraries/helpers.rb
    +++ b/libraries/helpers.rb
    @@ -14,7 +14,6 @@ class Chef
               selinux_disabled = getenforce.stdout =~ /disabled/i
             end

    -        if getenforce.stdout =~ /Disabled|/i
             # return false only when SELinux is disabled and it's allowed
             return_val = !(selinux_disabled && new_resource.allowed_disabled)
             Chef::Log.warn('SELinux is disabled / unreachable, skipping') unless return_val
    $ ruby -c libraries/helpers.rb
    Syntax OK