### PR TITLE
Add /sbin path to semanage and setsebool commands

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,7 +24,7 @@ class Chef
         persist_string = persist ? '-P ' :  ''
         new_value = new_resource.value ? 'on' : 'off'
         execute "selinux-setbool-#{new_resource.name}-#{new_value}" do
-          command "setsebool #{persist_string} #{new_resource.name} #{new_value}"
+          command "/sbin/setsebool #{persist_string} #{new_resource.name} #{new_value}"
           not_if "getsebool #{new_resource.name} | grep '#{new_value}$' >/dev/null" unless new_resource.force
           only_if { use_selinux(new_resource) }
         end
@@ -65,7 +65,7 @@ class Chef
         }
 
         label_matcher = label ? "system_u:object_r:#{Regexp.escape(label)}:s0\\s*$" : ''
-        "semanage fcontext -l | grep -qP '^#{Regexp.escape(file_spec)}\\s+#{Regexp.escape(file_hash[file_type])}\\s+#{label_matcher}'"
+        "/sbin/semanage fcontext -l | grep -qP '^#{Regexp.escape(file_spec)}\\s+#{Regexp.escape(file_hash[file_type])}\\s+#{label_matcher}'"
       end
 
       def semanage_options(file_type)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -25,7 +25,7 @@ class Chef
         new_value = new_resource.value ? 'on' : 'off'
         execute "selinux-setbool-#{new_resource.name}-#{new_value}" do
           command "/sbin/setsebool #{persist_string} #{new_resource.name} #{new_value}"
-          not_if "getsebool #{new_resource.name} | grep '#{new_value}$' >/dev/null" unless new_resource.force
+          not_if "/sbin/getsebool #{new_resource.name} | grep '#{new_value}$' >/dev/null" unless new_resource.force
           only_if { use_selinux(new_resource) }
         end
       end

--- a/resources/fcontext.rb
+++ b/resources/fcontext.rb
@@ -38,7 +38,7 @@ end
 # Create if doesn't exist, do not touch if fcontext is already registered
 action :add do
   execute "selinux-fcontext-#{new_resource.secontext}-add" do
-    command "semanage fcontext -a #{semanage_options(new_resource.file_type)} -t #{new_resource.secontext} '#{new_resource.file_spec}'"
+    command "/sbin/semanage fcontext -a #{semanage_options(new_resource.file_type)} -t #{new_resource.secontext} '#{new_resource.file_spec}'"
     not_if fcontext_defined(new_resource.file_spec, new_resource.file_type)
     only_if { use_selinux(new_resource) }
     notifies :relabel, new_resource, :immediate
@@ -48,7 +48,7 @@ end
 # Delete if exists
 action :delete do
   execute "selinux-fcontext-#{new_resource.secontext}-delete" do
-    command "semanage fcontext #{semanage_options(new_resource.file_type)} -d '#{new_resource.file_spec}'"
+    command "/sbin/semanage fcontext #{semanage_options(new_resource.file_type)} -d '#{new_resource.file_spec}'"
     only_if fcontext_defined(new_resource.file_spec, new_resource.file_type, new_resource.secontext)
     only_if { use_selinux(new_resource) }
     notifies :relabel, new_resource, :immediate
@@ -57,7 +57,7 @@ end
 
 action :modify do
   execute "selinux-fcontext-#{new_resource.secontext}-modify" do
-    command "semanage fcontext -m #{semanage_options(new_resource.file_type)} -t #{new_resource.secontext} '#{new_resource.file_spec}'"
+    command "/sbin/semanage fcontext -m #{semanage_options(new_resource.file_type)} -t #{new_resource.secontext} '#{new_resource.file_spec}'"
     only_if { use_selinux(new_resource) }
     only_if fcontext_defined(new_resource.file_spec, new_resource.file_type)
     not_if  fcontext_defined(new_resource.file_spec, new_resource.file_type, new_resource.secontext)

--- a/resources/permissive.rb
+++ b/resources/permissive.rb
@@ -5,8 +5,8 @@ property :allow_disabled, [true, false], default: true
 # Create if doesn't exist, do not touch if port is already registered (even under different type)
 action :add do
   execute "selinux-permissive-#{new_resource.name}-add" do
-    command "semanage permissive -a '#{new_resource.name}'"
-    not_if  "semanage permissive -l | grep  '^#{new_resource.name}$'"
+    command "/sbin/semanage permissive -a '#{new_resource.name}'"
+    not_if  "/sbin/semanage permissive -l | grep  '^#{new_resource.name}$'"
     only_if { use_selinux }
   end
 end
@@ -14,8 +14,8 @@ end
 # Delete if exists
 action :delete do
   execute "selinux-port-#{new_resource.name}-delete" do
-    command "semanage permissive -d '#{new_resource.name}'"
-    not_if  "semanage permissive -l | grep  '^#{new_resource.name}$'"
+    command "/sbin/semanage permissive -d '#{new_resource.name}'"
+    not_if  "/sbin/semanage permissive -l | grep  '^#{new_resource.name}$'"
     only_if { use_selinux }
   end
 end

--- a/resources/port.rb
+++ b/resources/port.rb
@@ -19,7 +19,7 @@ end
 action :add do
   validate_port(new_resource.port)
   execute "selinux-port-#{new_resource.port}-add" do
-    command "semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
+    command "/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
     not_if port_defined(new_resource.protocol, new_resource.port, new_resource.secontext)
     not_if port_defined(new_resource.protocol, new_resource.port)
     only_if { use_selinux(new_resource) }
@@ -30,7 +30,7 @@ end
 action :delete do
   validate_port(new_resource.port)
   execute "selinux-port-#{new_resource.port}-delete" do
-    command "semanage port -d -p #{new_resource.protocol} #{new_resource.port}"
+    command "/sbin/semanage port -d -p #{new_resource.protocol} #{new_resource.port}"
     only_if port_defined(new_resource.protocol, new_resource.port)
     only_if { use_selinux(new_resource) }
   end
@@ -38,7 +38,7 @@ end
 
 action :modify do
   execute "selinux-port-#{new_resource.port}-modify" do
-    command "semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
+    command "/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
     only_if port_defined(new_resource.protocol, new_resource.port)
     not_if port_defined(new_resource.protocol, new_resource.port, new_resource.secontext)
     only_if { use_selinux(new_resource) }

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -14,15 +14,15 @@ describe 'selinux_policy boolean' do
 
   describe 'SetAndPersist' do
     it 'when value does not match' do
-      stub_command("getsebool httpd_can_network_connect_db | grep 'on$' >/dev/null").and_return(false)
-      stub_command("getsebool nagios_run_sudo | grep 'off$' >/dev/null").and_return(false)
+      stub_command("/sbin/getsebool httpd_can_network_connect_db | grep 'on$' >/dev/null").and_return(false)
+      stub_command("/sbin/getsebool nagios_run_sudo | grep 'off$' >/dev/null").and_return(false)
       expect(chef_run).to run_execute('selinux-setbool-httpd_can_network_connect_db-on')
       expect(chef_run).to run_execute('selinux-setbool-nagios_run_sudo-off')
     end
 
     it 'when value does match' do
-      stub_command("getsebool httpd_can_network_connect_db | grep 'on$' >/dev/null").and_return(true)
-      stub_command("getsebool nagios_run_sudo | grep 'off$' >/dev/null").and_return(true)
+      stub_command("/sbin/getsebool httpd_can_network_connect_db | grep 'on$' >/dev/null").and_return(true)
+      stub_command("/sbin/getsebool nagios_run_sudo | grep 'off$' >/dev/null").and_return(true)
       expect(chef_run).not_to run_execute('selinux-setbool-httpd_can_network_connect_db-on')
       expect(chef_run).not_to run_execute('selinux-setbool-nagios_run_sudo-off')
     end

--- a/spec/fcontext_spec.rb
+++ b/spec/fcontext_spec.rb
@@ -11,20 +11,20 @@ describe 'selinux_policy fcontext' do
 
   describe 'AddOrModify' do
     it 'creates when none' do
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(false)
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(false)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(false)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(false)
       expect(chef_run).to run_execute('selinux-fcontext-http_dir_t-add')
       expect(chef_run).not_to run_execute('selinux-fcontext-http_dir_t-modify')
     end
     it 'modifies when exists and mismatch' do
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(true)
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(false)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(true)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(false)
       expect(chef_run).not_to run_execute('selinux-fcontext-http_dir_t-add')
       expect(chef_run).to run_execute('selinux-fcontext-http_dir_t-modify')
     end
     it 'does nothing when match' do
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(true)
-      stub_command("semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(true)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+'").and_return(true)
+      stub_command("/sbin/semanage fcontext -l | grep -qP '^/tmp/test\\s+all\\ files\\s+system_u:object_r:http_dir_t:s0\\s*$'").and_return(true)
       expect(chef_run).not_to run_execute('selinux-fcontext-http_dir_t-add')
       expect(chef_run).not_to run_execute('selinux-fcontext-http_dir_t-modify')
     end


### PR DESCRIPTION
## Description
Add the full paths to `semanage` and `setsebool` commands so that they won't fail when run in an environment where `/sbin` is not part of `PATH.

### Issues Resolved
Fixes #85 #93 

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
