### PR TITLE
Add chefignore file

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -92,6 +92,7 @@ Policyfile.lock.json
 CONTRIBUTING*
 CHANGELOG*
 TESTING*
+MAINTAINERS.toml
 
 # Strainer #
 ############


### PR DESCRIPTION
We should have a `chefignore` file to not upload everything to the Chef server.

Copied this from chef-client repo.