### PR TITLE
Update - add `unified_mode true` to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to changes made in each version of the selinux_policy cookbook.
 
+## Unreleased
+
+- Add `unified_mode true` to resources
+
 ## 2.4.3 (2020-08-07)
 
 - Ship the correct license file since this cookbook was relicensed - [@tas50](https://github.com/tas50)

--- a/resources/boolean.rb
+++ b/resources/boolean.rb
@@ -4,6 +4,8 @@ property :value, [true, false]
 property :force, [true, false], default: false
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 # Set and persist
 action :setpersist do
   sebool(new_resource, true)

--- a/resources/fcontext.rb
+++ b/resources/fcontext.rb
@@ -6,6 +6,8 @@ property :secontext, String
 property :file_type, String, default: 'a', equal_to: %w(a f d c b s l p)
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 action :addormodify do
   run_action(:add)
   run_action(:modify)

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,5 +1,7 @@
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 action :install do
   case node['platform_family']
   when 'debian'

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -9,6 +9,8 @@ property :directory_source, String # Source directory for module source code. If
 property :cookbook, String # Related to directory
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 action :deploy do
   run_action(:fetch)
   run_action(:compile)

--- a/resources/permissive.rb
+++ b/resources/permissive.rb
@@ -2,6 +2,8 @@
 
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 # Create if doesn't exist, do not touch if port is already registered (even under different type)
 action :add do
   execute "selinux-permissive-#{new_resource.name}-add" do

--- a/resources/port.rb
+++ b/resources/port.rb
@@ -6,6 +6,8 @@ property :protocol, String, equal_to: %w(tcp udp)
 property :secontext, String
 property :allow_disabled, [true, false], default: true
 
+unified_mode true
+
 action :addormodify do
   # TODO: We can be a bit more clever here, and try to detect if it's already
   # there then modify


### PR DESCRIPTION
Resolves
```
The  resource in the selinux_policy cookbook should declare `unified_mode true` at 6 locations:
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/boolean.rb
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/fcontext.rb
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/install.rb
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/module.rb
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/permissive.rb
  - /tmp/kitchen/cache/cookbooks/selinux_policy/resources/port.rb
See https://docs.chef.io/deprecations_unified_mode/ for further details.
```

Signed-off-by: Wade Peacock <knightorc@xqqme.com>