### PR TITLE
Add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to changes made in each version of the selinux_policy cookbook.
 
+## Unreleased
+
+- Add deprecation notice to README
+
 ## 2.4.3 (2020-08-07)
 
 - Ship the correct license file since this cookbook was relicensed - [@tas50](https://github.com/tas50)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 This cookbook can be used to manage SELinux policies and components (rather than just enable / disable enforcing). I made it because I needed some SELinux settings done, and the `execute`s started to look annoying.
 
+> ## ⚠ This cookbook is deprecated ⚠
+>
+> Use the [`selinux` cookbook](https://github.com/sous-chefs/selinux) instead. That cookbook has all the resources that this cookbook does, and is properly tested on current platforms. This cookbook is no longer maintained.
+>
+> For more context, see sous-chefs/selinux#79.
+
 ## Requirements
 
 Needs an SELinux policy active (so its values can be managed). Can work with a disabled SELinux system (see attribute `allow_disabled`), which will generate warnings and do nothing (but won't break the run). Also requires SELinux's management tools, namely `semanage`, `setsebool` and `getsebool`. Tools are installed by the `selinux_policy::install` recipe (for RHEL/Debian and the like).


### PR DESCRIPTION
# Description

This cookbook was silently deprecated as of sous-chefs/selinux#79. This PR adds a deprecation notice to this cookbook's README directing users to use `selinux` instead, as this cookbook is not being actively maintained anymore.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
